### PR TITLE
Proper deletion for array initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ IF(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "DEBUG")
 ENDIF(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "DEBUG")
 
 SET(CMAKE_REQUIRED_FLAGS "-std=c++17")
+add_compile_options(-Wall -Wextra -W)
 
 include(CheckCXXSourceCompiles)
 check_cxx_source_compiles(

--- a/src/api/comm/Buffer.h
+++ b/src/api/comm/Buffer.h
@@ -13,6 +13,8 @@ namespace twister::comm {
         int limit;
         int index = 0;
 
+        Buffer() = delete;
+
     public:
         explicit Buffer(int &size) {
             this->buff = new byte[size];

--- a/src/api/comm/Buffer.h
+++ b/src/api/comm/Buffer.h
@@ -21,6 +21,10 @@ namespace twister::comm {
             this->limit = size;
         }
 
+        ~Buffer() {
+            clear();
+        }
+
         bool put_int(int val) {
             if (index + 4 < this->limit) {
                 memcpy(this->buff + index, &val, 4);
@@ -42,7 +46,7 @@ namespace twister::comm {
         }
 
         void clear() {
-            delete this->buff;
+            delete [] this->buff;
             this->index = 0;
         }
     };

--- a/src/api/config/Config.h
+++ b/src/api/config/Config.h
@@ -1,7 +1,7 @@
 #ifndef TWISTERX_CONFIG_H
 #define TWISTERX_CONFIG_H
 
-#include <map>
+#include <unordered_map>
 #include <string>
 #include <any>
 
@@ -11,7 +11,7 @@ namespace twister::config {
     class Config {
 
     private:
-        map<string, any> config;
+        std::unordered_map<string, any> config;
 
     public:
         string get_string(const string &key);
@@ -23,4 +23,5 @@ namespace twister::config {
         void put_int(const string &key, const int &val);
     };
 }
+
 #endif //TWISTERX_CONFIG_H


### PR DESCRIPTION
- Fixed memory leak of Buffer class adding a destructor
- Changed config class map to a unordered_map
   Think this is valid hashmap for configurations
- added compiler flags to enable extra compiler warnings
