### PR TITLE
Extra compiler warning and ignore "build" folder from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@
 *~
 *.swp
 *.swo
+
+# ignore these folders
+build/
+**/bin/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ IF(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "DEBUG")
 ENDIF(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "DEBUG")
 
 SET(CMAKE_REQUIRED_FLAGS "-std=c++17")
+add_compile_options(-Wall -Wextra -W)
 
 include(CheckCXXSourceCompiles)
 check_cxx_source_compiles(


### PR DESCRIPTION
- added "-W -Wall -Wextra" compiler flags
- ignore "build" and "**/bin" folders from .gitignore file