### PR TITLE
adding initial commit on pybind-python api

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,48 @@ Optimized dataflow operations
 # Build instructions
    - Build any MPI of preference
    - Update LD_LIBRARY_PATH to include lib directory containing MPI libraries
+   - First go to the `cpp` directory,
    - Create a directory `build`
    - `cd build`
    - `cmake -DCMAKE_BUILD_TYPE=Debug ../`
    - `make -j4`
    
+
+## Python Support
+
+TwisterX provides Python APIs with Pybind11. 
+
+### Pre-requisites
+
+1. Install CMake 3.16.5
+
+```bash
+wget https://github.com/Kitware/CMake/releases/download/v3.16.5/cmake-3.16.5.tar.gz
+tar zxf cmake-3.16.5.tar.gz
+./bootstrap --system-curl
+make 
+sudo make install
+```
+
+2. Install Pybind11 
+
+```bash
+pip3 install pybind11
+sudo apt-get install python-pybind11
+```
+
+3. Install Python Library From Source
+
+```bash
+cd cpp
+python3 setup.py install
+```
+
+4. Test Python API
+
+```bash
+python3 python/test/test_twister.py
+```
+
+
+

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -27,6 +27,9 @@ SET(TEST_DATA_DIR ${TWISTERX_SOURCE_DIR}/data)
 find_package(MPI REQUIRED)
 include_directories(${MPI_CXX_INCLUDE_PATH})
 
+# Find Pybind11
+find_package(pybind11 REQUIRED)
+
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     message(STATUS "No build type selected, default to Debug")
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type (default Debug)" FORCE)
@@ -120,3 +123,5 @@ endif()
 add_subdirectory(src)
 add_subdirectory(example)
 
+## pybind11 python wrapper build
+pybind11_add_module(pytwisterx src/pybind/pytwisterx.cpp)

--- a/cpp/setup.py
+++ b/cpp/setup.py
@@ -1,0 +1,69 @@
+import os
+import re
+import sys
+import platform
+import subprocess
+
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+from distutils.version import LooseVersion
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, sourcedir=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+
+class CMakeBuild(build_ext):
+    def run(self):
+        try:
+            out = subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError("CMake must be installed to build the following extensions: " +
+                               ", ".join(e.name for e in self.extensions))
+
+        if platform.system() == "Windows":
+            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
+            if cmake_version < '3.1.0':
+                raise RuntimeError("CMake >= 3.1.0 is required on Windows")
+
+        for ext in self.extensions:
+            self.build_extension(ext)
+
+    def build_extension(self, ext):
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+
+        cfg = 'Debug' if self.debug else 'Release'
+        build_args = ['--config', cfg]
+
+        if platform.system() == "Windows":
+            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
+            if sys.maxsize > 2**32:
+                cmake_args += ['-A', 'x64']
+            build_args += ['--', '/m']
+        else:
+            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
+            build_args += ['--', '-j2']
+
+        env = os.environ.copy()
+        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
+                                                              self.distribution.get_version())
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
+
+setup(
+    name='pytwisterx',
+    version='0.0.1',
+    author='Vibhatha Abeykoon',
+    author_email='vibhatha@gmail.com',
+    description='A test project using pybind11 and CMake',
+    long_description='',
+    ext_modules=[CMakeExtension('pytwisterx')],
+    cmdclass=dict(build_ext=CMakeBuild),
+    zip_safe=False,
+)

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(twisterx SHARED all_to_all.cpp all_to_all.hpp channel.hpp mpi_channel.hpp mpi_channel.cpp arrow/arrow_all_to_all.cpp arrow/arrow_all_to_all.hpp join/join.hpp join/join.cpp util/arrow_utils.hpp util/arrow_utils.cpp arrow/arrow_kernels.cpp arrow/arrow_kernels.hpp util/copy_arrray.cpp join/join_utils.hpp join/join_utils.cpp arrow/arrow_join.cpp arrow/arrow_join.hpp util/sort_indices.cpp)
+add_library(twisterx SHARED all_to_all.cpp all_to_all.hpp channel.hpp mpi_channel.hpp mpi_channel.cpp arrow/arrow_all_to_all.cpp arrow/arrow_all_to_all.hpp join/join.hpp join/join.cpp util/arrow_utils.hpp util/arrow_utils.cpp arrow/arrow_kernels.cpp arrow/arrow_kernels.hpp util/copy_arrray.cpp join/join_utils.hpp join/join_utils.cpp arrow/arrow_join.cpp arrow/arrow_join.hpp util/sort_indices.cpp
+        lib/library.h lib/library.cpp)
 
 include_directories(${MPI_INCLUDE_PATH})
 target_link_libraries(twisterx ${MPI_LIBRARIES})

--- a/cpp/src/lib/library.cpp
+++ b/cpp/src/lib/library.cpp
@@ -1,0 +1,28 @@
+//
+// Created by vibhatha on 3/6/20.
+//
+
+#include "library.h"
+#include <iostream>
+
+
+struct Request {
+    Request(const std::string &name, int bufSize, std::string &message) : name(name), bufSize(bufSize),
+                                                                          message(message) {}
+
+    void setName(const std::string &name_) { name = name_; }
+
+    const std::string &getName() const { return name; }
+
+    void setMessage(std::string &message_) { message = message_; }
+
+    std::string &getMessage() { return message; }
+
+    void setBufSize(int size_) { bufSize = size_; }
+
+    int getBufSize() { return bufSize; }
+
+    std::string name;
+    int bufSize;
+    std::string message;
+};

--- a/cpp/src/lib/library.h
+++ b/cpp/src/lib/library.h
@@ -1,0 +1,10 @@
+//
+// Created by vibhatha on 3/6/20.
+//
+
+#ifndef CPP_LIBRARY_H
+#define CPP_LIBRARY_H
+
+
+
+#endif //CPP_LIBRARY_H

--- a/cpp/src/pybind/pytwisterx.cpp
+++ b/cpp/src/pybind/pytwisterx.cpp
@@ -1,0 +1,19 @@
+//
+// Created by vibhatha on 3/6/20.
+//
+
+#include "../lib/library.cpp"
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(pytwisterx, m) {
+    py::class_<Request>(m, "Request")
+            .def(py::init<const std::string &, int, std::string &>())
+            .def("setName", &Request::setName)
+            .def("getName", &Request::getName)
+            .def("setMessage", &Request::setMessage)
+            .def("getMessage", &Request::getMessage)
+            .def("setBufSize", &Request::setBufSize)
+            .def("getBufSize", &Request::getBufSize);
+}

--- a/python/test/test_twisterx.py
+++ b/python/test/test_twisterx.py
@@ -1,0 +1,11 @@
+import pytwisterx as tx
+
+r = tx.Request('m1', 4, 'Hello')
+
+assert r.getName() == 'm1'
+assert r.getBufSize() == 4
+assert r.getMessage() == 'Hello'
+
+
+
+


### PR DESCRIPTION
Adding the initial build setup for TwisterX python with Pybind11.

## Additions

1. Pybind11 setup
2. A basic example of adding a simple CPP class with a python library. 
3. Build setup with existing CPP build
4. Adding an initial python library

## Possible Changes

1. setup.py must go out of CPP folder and must be in the repo base. 

For this either we can add another layer of CMakeList or update setup.py script.

What should be the best? There can be better ways to do this. 